### PR TITLE
Add TextMate 2 to the list of editors supporting Hasklig

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Hasklig solves this problem the way typographers have always solved ill-fitting 
 + KWrite
 + Leksah (_x64 W8 reported not working_)
 + TextEdit
++ TextMate (from version 2.0-alpha.9549)
 
 ### No support
 - Aquamacs


### PR DESCRIPTION
TextMate 2 has now added support for Hasklig, and I'm successfully using it (with my Perl code...)

![screen shot 2014-07-06 at 23 21 30](https://cloud.githubusercontent.com/assets/7347955/3490133/e6a2f580-055b-11e4-9947-a46ef27ff978.png)
