### PR TITLE
make font compatible with IntelliJ IDEs

### DIFF
--- a/features.family
+++ b/features.family
@@ -31,7 +31,9 @@ dieresismacron.cap dieresisacute.cap dieresiscaron.cap dieresisgrave.cap circumf
 
 
 #--------------------------------------
-languagesystem DFLT dflt;
+languagesystem zyyy dflt;
+languagesystem zinh dflt;
+languagesystem grek dflt;
 languagesystem latn dflt;
 
 


### PR DESCRIPTION
IntelliJ IDEs are Java-based applications. Java SE currently uses ICU text layout engine (http://userguide.icu-project.org/layoutengine) internally, which doesn't support DFLT script tag, as required by the latest version of OpenType specification. So OpenType features (like ligatures), mapped to DFLT script, won't be properly recognized in all cases for Hasklig and similar fonts, when they are used in Java applications.

ICU engine is officially deprecated and JDK developers are working on a migration to Harfbuzz, which doesn't have such issues. But this change won't be released earlier than in spring 2017, and then some time will definitely pass before that release could be adopted by IntelliJ platform. So the proposal is to make a change to the font, so that it will be available to IntelliJ users much faster.

This change replaces DFLT tag in features mapping with tags of scripts actually supported by font. I'm not aware of any negative effects of such a change. I've done a smoke test of patched font in the following editors and didn't notice anything bad happening:
* Windows: Atom, Light Table
* Linux: Kate, Konsole, KWrite, gEdit, Geany
* Mac OS X: TextEdit, TextMate, BBEdit, Chocolat, MacVim, Smultron, Vico