### PR TITLE
Readme: add <| and |>

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Not only can multi-character glyphs be rendered more vividly, other problematic 
 + v0.1: Ligatures `<-` `->` `=>` `>>` `<<` `>>=` `=<<` `..` `...` `::` `-<` `>-` `-<<` `>>-` `++` `/=` and `==`
 
 #### Currently implemented symbols
-`<*` `<*>` `<+>` `<$>` `***`  `<|>` `!!` `||` `===` `==>` `<<<` `>>>` `<>` `+++` `<-` `->` `=>` `>>` `<<` `>>=` `=<<` `..` `...` `::` `-<` `>-` `-<<` `>>-` `++` `/=` `==`
+`<*` `<*>` `<+>` `<$>` `***` `<|` `|>`  `<|>` `!!` `||` `===` `==>` `<<<` `>>>` `<>` `+++` `<-` `->` `=>` `>>` `<<` `>>=` `=<<` `..` `...` `::` `-<` `>-` `-<<` `>>-` `++` `/=` `==`
 
 #### Editor Support
 This list is compiled based on reports on the current state of support for code editors and terminals. This list 


### PR DESCRIPTION
I've suddenly found that `<|` and `|>` are supported though it isn't mentioned in Readme. Please add these, that's very good news!