### PR TITLE
Add uvs.txt from SCP upstream to fix build failure after fe063b4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,8 @@
 *.tmp
-
 *.zip
-
 *.cff
-
-*.txt
-
 *.otf
-
 *.ttf
-
 *.log
 
 font.ufo/

--- a/uvs.txt
+++ b/uvs.txt
@@ -1,0 +1,29 @@
+# http://www.unicode.org/reports/tr51/index.html#Emoji_Variation_Sequences
+# FE0E text style
+# FE0F emoji style
+
+# Test page
+# http://unicode.org/emoji/charts/emoji-style.html
+
+# Standard variation sequences
+# http://unicode.org/emoji/charts/emoji-variants.html
+
+# Code point / Variation selector / Final glyph name
+
+2611 FE0F; uni2611_uniFE0F
+2615 FE0F; uni2615_uniFE0F
+263A FE0F; uni263A_uniFE0F
+263B FE0F; uni263B_uniFE0F
+2660 FE0F; uni2660_uniFE0F
+2663 FE0F; uni2663_uniFE0F
+2665 FE0F; uni2665_uniFE0F
+2666 FE0F; uni2666_uniFE0F
+2713 FE0F; uni2713_uniFE0F
+2764 FE0F; uni2764_uniFE0F
+266A FE0F; u1F3B5_uniFE0F
+1F3B5 FE0F; u1F3B5_uniFE0F
+1F3B6 FE0F; u1F3B6_uniFE0F
+266B FE0F; u1F3B6_uniFE0F
+1F4A9 FE0F; u1F4A9_uniFE0F
+1F512 FE0F; u1F512_uniFE0F
+1F916 FE0F; u1F916_uniFE0F


### PR DESCRIPTION
fe063b4 adds `$UVS` to `build.sh`, hence the build process will fail if `uvs.txt` does not exist.