### PR TITLE
Build debian support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/buildVFs.sh
+++ b/buildVFs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 ro_name=SourceCodeVariable-Roman
 it_name=SourceCodeVariable-Italic

--- a/makeInstances.sh
+++ b/makeInstances.sh
@@ -1,2 +1,10 @@
+#!/usr/bin/env bash
+
+# We're just testing if 'makeInstancesUFO' exists, otherwise we'll attempt to use the lowercase varient.
+function makeInstancesUFO() { 
+  [[ -z "$(which makeInstancesUFO)" ]] \
+    && makeinstancesufo $argv || makeInstancesUFO $argv
+}
+
 makeInstancesUFO -d Roman/Masters/SourceCodePro.designspace
 makeInstancesUFO -d Italic/Masters/SourceCodePro-Italic.designspace

--- a/makeInstances.sh
+++ b/makeInstances.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# We're just testing if 'makeInstancesUFO' exists, otherwise we'll attempt to use the lowercase varient.
+# We're just testing if 'makeInstancesUFO' exists, otherwise we'll attempt to use the lowercase variant.
 function makeInstancesUFO() { 
   [[ -z "$(which makeInstancesUFO)" ]] \
     && makeinstancesufo $argv || makeInstancesUFO $argv


### PR DESCRIPTION
This PR addresses a couple of small build issues I had while attempting to build Hasklig (environment dump below). These changes shouldn't affect the current build process but should expand build support to Linux systems.

1. Build scripts are now executed under the BASH runtime rather than SH.
![image](https://user-images.githubusercontent.com/5634516/140784650-a9491c69-0ea0-45b2-b29b-06ea0e68d26a.png)

2. makeInstances.sh supports the case-sensitive version of 'makeinstancesufo'.
![image](https://user-images.githubusercontent.com/5634516/140784758-4736bca6-5254-4dee-816f-68b2003fe4e1.png)


Environment Dump:
```
  Operating System: Ubuntu 21.04
            Kernel: Linux 5.11.0-38-generic
      Architecture: x86-64
```